### PR TITLE
autocomplete-example-json: implement demo for json web editor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ write-fixtures: ## Write new test fixtures
 test: ## Run all tests
 	@go test .
 	@go test ./validate
+
+.PHONY: run-web-editor-json
+run-web-editor-json: ## show a demo-web editor for the json format
+	xdg-open ./autocomplete-example-json.html

--- a/autocomplete-example-json.html
+++ b/autocomplete-example-json.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Monaco Editor with JSON Schema Autocomplete</title>
+  <style>
+    html, body, #container {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div id="container"></div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.7/require.min.js"></script>
+  <script>
+    require.config({ paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.2/min/vs' }});
+
+    require(['vs/editor/editor.main'], function () {
+
+      // Fetch the JSON Schema from the web
+      fetch('https://raw.githubusercontent.com/lzap/common-blueprint-example/refs/heads/main/blueprint-schema.json')
+        .then(function(response) {
+          return response.json();
+        })
+        .then(function(schema) {
+          monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+            validate: true,
+            allowComments: true,
+            schemas: [{
+              uri: 'https://raw.githubusercontent.com/lzap/common-blueprint-example/refs/heads/main/blueprint-schema.json',
+              fileMatch: ['*'],
+              schema: schema
+            }]
+          });
+
+          // Create the Monaco Editor instance with some initial JSON content
+          monaco.editor.create(document.getElementById('container'), {
+            value: `{
+  "name": "",
+  "description": "",
+  "registration": {
+    "redhat": {
+      "activation_key": "",
+      "organization": ""
+    }
+  },
+  "network": {
+    "firewall": {
+      "services": [
+        {
+          "service": ""
+        }
+      ]
+    }
+  }
+}`,
+            language: 'json',
+            theme: 'vs-light',
+          });
+        })
+        .catch(function(error) {
+          console.error('Error loading JSON Schema:', error);
+        });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
I just wanted to see if we can do a simple auto-complete demo and if the schema syntax is compatible.

Things I found:
  * Autocomplete does suggest the properties of the schema
     but also suggests properties from other objects
     (although `"additionalProperties": false,` seems to be set correctly)
     and selecting the property from autocompete adds it without quotation marks (but I guess that's just the editor, not the schema)
  * Hovering over a property correctly shows the `description`
  
Using the same schema to do yaml-autocomplete editor seems more complicated.